### PR TITLE
Add download_links file and strengthen filename uniqueness

### DIFF
--- a/pkg/rustmaps/config_test.go
+++ b/pkg/rustmaps/config_test.go
@@ -32,6 +32,16 @@ func TestGenerator_LoadConfig(t *testing.T) {
 			}),
 			wantErr: true,
 		},
+		{
+			name: "Test LoadConfig fail tmp",
+			generator: NewMockedGenerator(t, &Generator{
+				configPath: "/tmp/",
+				config:     types.Config{},
+				maps:       []*types.Map{},
+				rmcli:      &api.RustMapsClient{},
+			}),
+			wantErr: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/rustmaps/config_test.go
+++ b/pkg/rustmaps/config_test.go
@@ -23,6 +23,16 @@ func TestGenerator_LoadConfig(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "Test LoadConfig with file",
+			generator: NewMockedGenerator(t, &Generator{
+				configPath: "/etc/hosts",
+				config:     types.Config{},
+				maps:       []*types.Map{},
+				rmcli:      &api.RustMapsClient{},
+			}),
+			wantErr: true,
+		},
+		{
 			name: "Test LoadConfig fail",
 			generator: NewMockedGenerator(t, &Generator{
 				configPath: "/tmp/asdfjasdlf/sadf432323/./.23",
@@ -58,7 +68,25 @@ func TestGenerator_SaveConfig(t *testing.T) {
 		generator *Generator
 		wantErr   bool
 	}{
-		// TODO: Add test cases.
+		{
+			name: "Test SaveConfig",
+			generator: NewMockedGenerator(t, &Generator{
+				config: types.Config{},
+				maps:   []*types.Map{},
+				rmcli:  &api.RustMapsClient{},
+			}),
+			wantErr: false,
+		},
+		{
+			name: "Test SaveConfig fail",
+			generator: NewMockedGenerator(t, &Generator{
+				configPath: "/tmp/asdfjasdlf/sadf432323/./.23",
+				config:     types.Config{},
+				maps:       []*types.Map{},
+				rmcli:      &api.RustMapsClient{},
+			}),
+			wantErr: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/rustmaps/download.go
+++ b/pkg/rustmaps/download.go
@@ -101,11 +101,12 @@ func (g *Generator) Download(log *zap.Logger, version string) error {
 			if savedConfig == "" {
 				savedConfig = "procedural"
 			}
-			mapTarget := filepath.Join(downloadsDir, fmt.Sprintf("%s_%d_%s_%t_%s.map", m.Seed, m.Size, savedConfig, m.Staging, m.MapID))
-			imageTarget := filepath.Join(downloadsDir, fmt.Sprintf("%s_%d_%s_%t_%s.png", m.Seed, m.Size, savedConfig, m.Staging, m.MapID))
-			imageWithIconsTarget := filepath.Join(downloadsDir, fmt.Sprintf("%s_%d_%s_%t_%s_icons.png", m.Seed, m.Size, savedConfig, m.Staging, m.MapID))
-			thumbnailTarget := filepath.Join(downloadsDir, fmt.Sprintf("%s_%d_%s_%t_%s_thumbnail.png", m.Seed, m.Size, savedConfig, m.Staging, m.MapID))
-			downloadLinksTarget := filepath.Join(downloadsDir, fmt.Sprintf("%s_%d_%s_%t_%s_download_links.json", m.Seed, m.Size, savedConfig, m.Staging, m.MapID))
+			prefix := fmt.Sprintf("%s_%d_%s_%t_%s", m.Seed, m.Size, savedConfig, m.Staging, m.MapID)
+			mapTarget := filepath.Join(downloadsDir, fmt.Sprintf("%s.map", prefix))
+			imageTarget := filepath.Join(downloadsDir, fmt.Sprintf("%s.png", prefix))
+			imageWithIconsTarget := filepath.Join(downloadsDir, fmt.Sprintf("%s_icons.png", prefix))
+			thumbnailTarget := filepath.Join(downloadsDir, fmt.Sprintf("%s_thumbnail.png", prefix))
+			downloadLinksTarget := filepath.Join(downloadsDir, fmt.Sprintf("%s_download_links.json", prefix))
 			// create a json file next to the rest that contains the download urls
 			log.Info("Downloading assets", zap.String("seed", m.Seed), zap.String("map_id", m.MapID))
 			links := DownloadLinks{


### PR DESCRIPTION
# Add download_links file and strengthen filename uniqueness

## Changes Made
*Describe the changes you've made in this pull request. What does this PR do?*

- Downloads an additional file alongside the map/images. It's a json file (named similarly to its associated map) that contains download links for future use/reference.
- Added more map characteristics (saved config, staging) to the filename convention for downloads 

## Motivation and Context
*Why is this change required? What problem does it solve?*
- Allows external tools to:
  - find the maps easier
  - perform arbitrary work on the maps and images

*If it fixes an open issue, please link to the issue here.*

## Type of Change
**Please check the options that are relevant:**
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] This change requires a documentation update

## Testing Performed
**Describe the tests you ran to verify your changes:**
- tests running in ci
- tested locally and on a remote machine

## Screenshots (if appropriate)
*Add screenshots to help explain your changes.*

naming convention is now `$seed_$size_$saved_config_$staging_$mapid_...json`

![clipboard_2025-02-17_16-36](https://github.com/user-attachments/assets/a4feb37c-e8fe-41e6-a48f-8bcc003955c2)

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
